### PR TITLE
Fix: Invalid haml in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add to your application.scss:
 Simple example haml for your views:
 
     div#uploader
-    javascript:
+    :javascript
       $(function(){
         $("#uploader").pluploadQueue({
           runtimes: 'gears,flash,silverlight,browserplus,html5',


### PR DESCRIPTION
Haml throws the error

> Illegal nesting: nesting within plain text is illegal.

because the : is in the wrong location
