### PR TITLE
updated to to work with jquery names other than $

### DIFF
--- a/app/assets/javascripts/plupload.settings.js.erb
+++ b/app/assets/javascripts/plupload.settings.js.erb
@@ -1,5 +1,5 @@
 // Assigns default Plupload settings that work with the asset pipeline.
-(function () {
+(function ($) {
   var proxied = plupload.Uploader;
   
   plupload.Uploader = function (settings) {
@@ -11,4 +11,4 @@
     
     return proxied.apply(this, [settings]);
   };
-}());
+}(jQuery));


### PR DESCRIPTION
$ is just an alias for jQuery. Plugins should not assume that $ works directly. There can be conflict when using other libraries.

example e.g. in: https://github.com/moxiecode/plupload/blob/master/js/jquery.plupload.queue/jquery.plupload.queue.js
