### PR TITLE
Bumps the version numbers, tweaks the readme for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Rails Integration for Plupload
 ==
 
-This gem integrates [Plupload](http://www.plupload.com/) with the Rails >= 3.1 asset pipeline. It's been tested with Rails 3.1, 3.2 and 4.0.
-
-To use it with Rails 4, please fetch the gem from upstream: `gem 'plupload-rails', github: 'gucki/plupload-rails'`
+This gem integrates [Plupload](http://www.plupload.com/) with Rails. It's been tested with Rails 3.1, 3.2 and 4.0.
 
 
 Install

--- a/lib/plupload/rails/version.rb
+++ b/lib/plupload/rails/version.rb
@@ -1,7 +1,6 @@
 module Plupload
-  VERSION = "1.5.2"
+  VERSION = "2.0.0"
   module Rails
-    VERSION = "1.0.6"
+    VERSION = "1.1.0"
   end
 end
-


### PR DESCRIPTION
@gucki, I think we could release a new version of `plupload-rails` now that it's been updated for plupload 2.0.0.

Merging this into master and then releasing it should do the trick… I bumped the version number up to 1.1.0.
